### PR TITLE
fix: iOS - aborting local image asset load for empty mobileId

### DIFF
--- a/iOS/Sources/Beagle/Sources/Components/Image+Renderable/Image+Renderable.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Image+Renderable/Image+Renderable.swift
@@ -37,7 +37,7 @@ extension Image: Widget {
         case .local(let mobileId):
             let expression: Expression<String> = "\(mobileId)"
             renderer.observe(expression, andUpdateManyIn: image) { mobileId in
-                guard let mobileId = mobileId else { return }
+                guard let mobileId = mobileId, !mobileId.isEmpty else { return }
                 self.setImageFromAsset(named: mobileId, bundle: renderer.controller.dependencies.appBundle, imageView: image)
             }
         case .remote(let remote):


### PR DESCRIPTION
Avoids console execution warning log *[framework] CUICatalog: Invalid asset name supplied: ''*


### Related Issues
#1242
<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->

### Description and Example

<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most imporant thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
